### PR TITLE
Drop columns info from Forest.

### DIFF
--- a/syndiffix/forest.py
+++ b/syndiffix/forest.py
@@ -17,14 +17,12 @@ class Forest:
         self,
         anonymization_context: AnonymizationContext,
         bucketization_params: BucketizationParams,
-        columns: Columns,
         counters_factory: CountersFactory,
         aids: DataFrame,
         data: DataFrame,
     ) -> None:
         self.anonymization_context = anonymization_context
         self.bucketization_params = bucketization_params
-        self.columns = columns
         self.counters_factory = counters_factory
 
         assert len(aids) == len(data)
@@ -48,7 +46,7 @@ class Forest:
         self.aid_data: npt.NDArray[np.uint64] = aids.applymap(hash_aid).to_numpy(Hash)
         # Arrange data in a numpy array, applying the null mappings to missing values.
         # `DataFrame.fillna` doesn't seem to accept the fill values by index, must build dict.
-        null_mapping_dict = {c.name: self.null_mappings[i] for i, c in enumerate(columns)}
+        null_mapping_dict = {c: self.null_mappings[i] for i, c in enumerate(data.columns)}
         data.fillna(null_mapping_dict, axis=0, inplace=True)
         self.data: npt.NDArray[np.float_] = data.to_numpy(np.float_)
 


### PR DESCRIPTION
We don't need the type and we have the names in the dataframe.