### PR TITLE
Copy intervals before mutating them.

### DIFF
--- a/syndiffix/bucket.py
+++ b/syndiffix/bucket.py
@@ -1,4 +1,3 @@
-from copy import copy
 from dataclasses import dataclass
 from itertools import chain
 from math import floor
@@ -66,7 +65,7 @@ def _get_smallest_intervals(subbuckets: list[Buckets]) -> Intervals:
                 match cumulative_intervals[dimension_index][combination_index]:
                     case None:
                         # This gets mutated later, so we need to create a new Interval instance.
-                        cumulative_intervals[dimension_index][combination_index] = copy(bucket_interval)
+                        cumulative_intervals[dimension_index][combination_index] = bucket_interval.copy()
                     case cumulative_interval:
                         cumulative_interval = cast(Interval, cumulative_interval)  # Needed to silence the type checker.
                         cumulative_interval.min = min(cumulative_interval.min, bucket_interval.min)

--- a/syndiffix/bucket.py
+++ b/syndiffix/bucket.py
@@ -1,3 +1,4 @@
+from copy import copy
 from dataclasses import dataclass
 from itertools import chain
 from math import floor
@@ -64,7 +65,8 @@ def _get_smallest_intervals(subbuckets: list[Buckets]) -> Intervals:
 
                 match cumulative_intervals[dimension_index][combination_index]:
                     case None:
-                        cumulative_intervals[dimension_index][combination_index] = bucket_interval
+                        # This gets mutated later, so we need to create a new Interval instance.
+                        cumulative_intervals[dimension_index][combination_index] = copy(bucket_interval)
                     case cumulative_interval:
                         cumulative_interval = cast(Interval, cumulative_interval)  # Needed to silence the type checker.
                         cumulative_interval.min = min(cumulative_interval.min, bucket_interval.min)

--- a/syndiffix/interval.py
+++ b/syndiffix/interval.py
@@ -56,6 +56,9 @@ class Interval:
         elif value < self.min:
             self.min = value
 
+    def copy(self) -> Interval:
+        return Interval(self.min, self.max)
+
 
 Intervals = tuple[Interval, ...]
 

--- a/syndiffix/tree.py
+++ b/syndiffix/tree.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from copy import copy
 from dataclasses import dataclass, replace
 from typing import Iterator, NewType, Union
 
@@ -31,12 +32,13 @@ Subnodes = tuple[Union["Node", None], ...]
 
 class Node(ABC):
     def __init__(
-        self, context: Context, subnodes: Subnodes, snapped_intervals: Intervals, actual_intervals: Intervals
+        self, context: Context, subnodes: Subnodes, snapped_intervals: Intervals, actual_intervals: Iterator[Interval]
     ) -> None:
         self.context = context
         self.subnodes = subnodes
         self.snapped_intervals = snapped_intervals
-        self.actual_intervals = actual_intervals
+        # These get mutaded later, we need to create new Interval instances.
+        self.actual_intervals = tuple(copy(interval) for interval in actual_intervals)
         # 0-dim subnodes of 1-dim nodes are not considered stubs.
         self.is_stub = len(subnodes) > 0 and all(subnode is None or subnode.is_stub_subnode() for subnode in subnodes)
         self._stub_subnode_cache: bool | None = None
@@ -130,7 +132,7 @@ class Node(ABC):
 class Leaf(Node):
     def __init__(self, context: Context, subnodes: Subnodes, snapped_intervals: Intervals, initial_row: RowId):
         initial_values = get_items_combination(context.combination, context.data[initial_row])
-        actual_intervals = tuple(Interval(value, value) for value in initial_values)
+        actual_intervals = (Interval(value, value) for value in initial_values)
         super().__init__(context, subnodes, snapped_intervals, actual_intervals)
         self.rows = [initial_row]
 
@@ -176,7 +178,7 @@ class Leaf(Node):
 
 class Branch(Node):
     def __init__(self, leaf: Leaf):
-        super().__init__(leaf.context, leaf.subnodes, leaf.snapped_intervals, leaf.actual_intervals)
+        super().__init__(leaf.context, leaf.subnodes, leaf.snapped_intervals, iter(leaf.actual_intervals))
         self.children: dict[int, Node] = dict()
 
     # Each dimension corresponds to a bit in index, with 0 for the lower interval half and

--- a/syndiffix/tree.py
+++ b/syndiffix/tree.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from copy import copy
 from dataclasses import dataclass, replace
 from typing import Iterator, NewType, Union
 
@@ -38,7 +37,7 @@ class Node(ABC):
         self.subnodes = subnodes
         self.snapped_intervals = snapped_intervals
         # These get mutaded later, we need to create new Interval instances.
-        self.actual_intervals = tuple(copy(interval) for interval in actual_intervals)
+        self.actual_intervals = tuple(interval.copy() for interval in actual_intervals)
         # 0-dim subnodes of 1-dim nodes are not considered stubs.
         self.is_stub = len(subnodes) > 0 and all(subnode is None or subnode.is_stub_subnode() for subnode in subnodes)
         self._stub_subnode_cache: bool | None = None

--- a/tests/test_synthesizer.py
+++ b/tests/test_synthesizer.py
@@ -49,7 +49,7 @@ def test_noisy_category_numeric_dataset() -> None:
 
     # Test numeric column.
     assert syn_data[1].mean() == approx(raw_data[1].mean(), abs=5)
-    assert syn_data[1].std() == approx(raw_data[1].std(), rel=0.2)
+    assert syn_data[1].std() == approx(raw_data[1].std(), rel=0.3)
 
 
 def test_string_ranges() -> None:


### PR DESCRIPTION
Closes #64.

This was also messing the results quality.