### PR TITLE
Optimize generic entity counting.

### DIFF
--- a/syndiffix/synthesizer.py
+++ b/syndiffix/synthesizer.py
@@ -61,7 +61,13 @@ class Synthesizer(object):
             aids = pd.DataFrame({"RowIndex": range(1, len(raw_data) + 1)})
             counters_factory: CountersFactory = UniqueAidCountersFactory()
         else:
-            counters_factory = GenericAidCountersFactory(len(aids.columns))
+            low_count_params = anonymization_context.anonymization_params.low_count_params
+            # Stop counting entities over 4 standard deviations more than the mean of the range threshold.
+            # `low_mean_gap` is the number of standard deviations between `low_threshold` and desired mean.
+            max_low_count = bucketization_params.range_low_threshold + int(
+                (low_count_params.low_mean_gap + 4.0) * low_count_params.layer_sd
+            )
+            counters_factory = GenericAidCountersFactory(len(aids.columns), max_low_count)
 
         self.raw_dtypes = raw_data.dtypes
 

--- a/tests/test_counters.py
+++ b/tests/test_counters.py
@@ -4,6 +4,8 @@ from syndiffix.counters import *
 
 from .conftest import *
 
+MAX_LOW_COUNT = 20
+
 
 def _hash1(i: int) -> Hashes:
     return np.array([Hash(i)])
@@ -33,7 +35,7 @@ def test_unique_aid_noisy_count() -> None:
 
 
 def test_generic_aid_low_count() -> None:
-    counter = GenericAidCountersFactory(1).create_entity_counter()
+    counter = GenericAidCountersFactory(1, MAX_LOW_COUNT).create_entity_counter()
     assert counter.is_low_count(SALT, NOISELESS_SUPPRESSION)
     counter.add(_hash1(1))
     counter.add(_hash1(2))
@@ -51,7 +53,7 @@ def test_generic_aid_low_count() -> None:
 
 
 def test_generic_aid_noisy_count() -> None:
-    counter = GenericAidCountersFactory(1).create_row_counter()
+    counter = GenericAidCountersFactory(1, MAX_LOW_COUNT).create_row_counter()
     assert counter.noisy_count(NOISELESS_CONTEXT) == 0
     counter.add(_hash1(1))
     counter.add(_hash1(2))
@@ -75,7 +77,7 @@ def test_generic_aid_noisy_count() -> None:
 
 
 def test_multi_aid_low_count() -> None:
-    counter = GenericAidCountersFactory(2).create_entity_counter()
+    counter = GenericAidCountersFactory(2, MAX_LOW_COUNT).create_entity_counter()
     assert counter.is_low_count(SALT, NOISELESS_SUPPRESSION)
     counter.add(_hash2(1, 1))
     counter.add(_hash2(2, 2))
@@ -97,7 +99,7 @@ def test_multi_aid_low_count() -> None:
 
 def test_multi_aid_noisy_count_identical() -> None:
     # Both AIDs are identical - a simple sanity test.
-    counter = GenericAidCountersFactory(2).create_row_counter()
+    counter = GenericAidCountersFactory(2, MAX_LOW_COUNT).create_row_counter()
     assert counter.noisy_count(NOISELESS_CONTEXT) == 0
     counter.add(_hash2(1, 1))
     counter.add(_hash2(2, 2))
@@ -121,7 +123,7 @@ def test_multi_aid_noisy_count_identical() -> None:
 
 
 def test_multi_aid_noisy_count_divergent() -> None:
-    counter = GenericAidCountersFactory(2).create_row_counter()
+    counter = GenericAidCountersFactory(2, MAX_LOW_COUNT).create_row_counter()
     assert counter.noisy_count(NOISELESS_CONTEXT) == 0
     counter.add(_hash2(1, 1))
     counter.add(_hash2(2, 2))


### PR DESCRIPTION
We limit the max count of entities we keep track of and we use a small numpy array for the storage of unique AID hashes until we hit `max_low_count`.